### PR TITLE
Query feature

### DIFF
--- a/MfPulse.Auth/Implementation/Database/UserWriteOperations.cs
+++ b/MfPulse.Auth/Implementation/Database/UserWriteOperations.cs
@@ -17,12 +17,12 @@ namespace MfPulse.Auth.Implementation.Database
         
         public async Task<UserDocument> UpdateToken(string id, string newToken)
         {
-            return await UpdateOne(GetIdFilter(id), U.Set(x => x.CurrentToken, newToken));
+            return await UpdateOne(F.ById(id), U.Set(x => x.CurrentToken, newToken));
         }
 
         public async Task<UserDocument> ClearToken(string id)
         {
-            return await UpdateOne(GetIdFilter(id), U.Set(x => x.CurrentToken, null));
+            return await UpdateOne(F.ById(id), U.Set(x => x.CurrentToken, null));
         }
 
         public async Task<UserDocument> UpdateInfo(string id, string lastName, string firstName, string middleName)
@@ -32,12 +32,12 @@ namespace MfPulse.Auth.Implementation.Database
                 .Set(x=>x.FirstName, firstName)
                 .Set(x=>x.MiddleName, middleName);
 
-            return await UpdateOne(GetIdFilter(id), update);
+            return await UpdateOne(F.ById(id), update);
         }
 
         public async Task<UserDocument> UpdatePassword(string id, Password newPassword)
         {
-            return await UpdateOne(GetIdFilter(id), U.Set(x => x.Password, newPassword));
+            return await UpdateOne(F.ById(id), U.Set(x => x.Password, newPassword));
         }
     }
 }

--- a/MfPulse.Mongo/Operations/Implementations/BaseOperations.cs
+++ b/MfPulse.Mongo/Operations/Implementations/BaseOperations.cs
@@ -1,4 +1,6 @@
-﻿using MfPulse.Mongo.Document;
+﻿using System;
+using System.Threading.Tasks;
+using MfPulse.Mongo.Document;
 using MfPulse.Mongo.Security;
 using MongoDB.Driver;
 
@@ -16,6 +18,21 @@ namespace MfPulse.Mongo.Operations.Implementations
         {
             _mongoSecurityFilter = mongoSecurityFilter;
             Collection = dbContext.Database.GetCollection<TDocument>(typeof(TDocument).Name.Replace("Document", ""));
+        }
+
+        /// <summary>
+        /// Метод выполнения некой операции в монго с применением фильтров.
+        /// Применяет все SecureFilters для фильтра в операции 
+        /// </summary>
+        /// <param name="operation">Функция, которую необходимо выполнить</param>
+        /// <param name="filterDefinition">Фильтр, который необходимо обогатить и передать в функцию</param>
+        /// <typeparam name="TResult">Тип результата, который вернёт функция</typeparam>
+        /// <returns>Указанный результат в TResult</returns>
+        protected async Task<TResult> ExecuteOperation<TResult>(Func<FilterDefinition<TDocument>, Task<TResult>> operation, FilterDefinition<TDocument> filterDefinition)
+        {
+            filterDefinition &= _mongoSecurityFilter.GetSecureFilter(filterDefinition);
+            
+            return await operation(filterDefinition);
         }
     }
 }

--- a/MfPulse.Mongo/Operations/Implementations/GetOperations.cs
+++ b/MfPulse.Mongo/Operations/Implementations/GetOperations.cs
@@ -37,25 +37,22 @@ namespace MfPulse.Mongo.Operations.Implementations
         protected async Task<TDocument> One(FilterDefinition<TDocument> filter, bool isArchived = false)
         {
             filter &= F.Eq(x => x.IsArchived, isArchived);
-            filter &= _mongoSecurityFilter.GetSecureFilter(filter);
-            
-            return await (await Collection.FindAsync(filter)).FirstOrDefaultAsync();
+
+            return await ExecuteOperation(async x => await (await Collection.FindAsync(x)).FirstOrDefaultAsync(), filter);
         }
         
         protected async Task<List<TDocument>> Many(FilterDefinition<TDocument> filter, bool isArchived = false)
         {
             filter &= F.Eq(x => x.IsArchived, isArchived);
-            filter &= _mongoSecurityFilter.GetSecureFilter(filter);
 
-            return await (await Collection.FindAsync(filter)).ToListAsync();
+            return await ExecuteOperation(async x => await (await Collection.FindAsync(filter)).ToListAsync(), filter);
         }
         
         protected async Task<long> Count(FilterDefinition<TDocument> filter, bool isArchived = false)
         {
             filter &= F.Eq(x => x.IsArchived, isArchived);
-            filter &= _mongoSecurityFilter.GetSecureFilter(filter);
-            
-            return await Collection.CountDocumentsAsync(filter);
+
+            return await ExecuteOperation(async x =>await Collection.CountDocumentsAsync(filter), filter);
         }
     }
 }

--- a/MfPulse.Mongo/Operations/Implementations/WriteOperations.cs
+++ b/MfPulse.Mongo/Operations/Implementations/WriteOperations.cs
@@ -23,13 +23,19 @@ namespace MfPulse.Mongo.Operations.Implementations
 
         public async Task<TDocument> Delete(TDocument document)
         {
-            return await Collection.FindOneAndDeleteAsync<TDocument>(GetIdFilter(document.Id));
+            return await ExecuteOperation(
+                async x => await Collection.FindOneAndDeleteAsync<TDocument>(x),
+                F.ById(document.Id)
+                );
         }
 
         public async Task<TDocument> SafeDelete(TDocument document)
         {
             var update = U.Set(x => x.IsArchived, true);
-            return await Collection.FindOneAndUpdateAsync<TDocument>(GetIdFilter(document.Id), update);
+            return await ExecuteOperation(
+                async x => await Collection.FindOneAndUpdateAsync<TDocument>(x, update),
+                F.ById(document.Id)
+            );
         }
 
         public async Task<TDocument> Upsert(TDocument document)
@@ -39,28 +45,27 @@ namespace MfPulse.Mongo.Operations.Implementations
             {
                 IsUpsert = true
             };
-            return await Collection.FindOneAndReplaceAsync(GetIdFilter(document.Id), document, options);
+            return await ExecuteOperation(
+                async x => await Collection.FindOneAndReplaceAsync(x, document, options),
+                F.ById(document.Id)
+            );
         }
         
         protected async Task<TDocument> UpdateOne(FilterDefinition<TDocument> filter,
             UpdateDefinition<TDocument> update)
         {
-            filter &= _mongoSecurityFilter.GetSecureFilter(filter);
-            
-            return await Collection.FindOneAndUpdateAsync<TDocument>(filter, update);
+            return await ExecuteOperation(
+                async x => await Collection.FindOneAndUpdateAsync<TDocument>(x, update),
+                filter);
         }
         
         protected async Task UpdateMany(FilterDefinition<TDocument> filter,
             UpdateDefinition<TDocument> update)
         {
-            filter &= _mongoSecurityFilter.GetSecureFilter(filter);
-
-            await Collection.UpdateManyAsync(filter, update);
-        }
-
-        protected FilterDefinition<TDocument> GetIdFilter(string id)
-        {
-            return _mongoSecurityFilter.GetSecureFilter(F.ById(id));
+            await ExecuteOperation(
+                async x => await Collection.UpdateManyAsync(x, update),
+                filter);
+            
         }
     }
 }


### PR DESCRIPTION
Для выполнения разных операций в монге мы постоянно применяли SecureFillter - генератор фильтров по компании и пользователю. Вызывать постоянно `filter &= _mongoSecurityFilter.GetSecureFilter(filterDefiniion);`  немного раздражает и нарушает принцип DRY (Dont repeat yourself). Я написал отдельный метод `ExecuteOperation`, который позволяет выполнить некоторую операцию с фильтром, и который обогащает наш фильтр ограничениями из  `MongoSecurityFilter`.